### PR TITLE
Use /usr/bin/env python for shebang line

### DIFF
--- a/git-cclone
+++ b/git-cclone
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os, sys, subprocess, hashlib
 

--- a/git-scclone
+++ b/git-scclone
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os, sys, subprocess
 

--- a/git-submodule-cclone
+++ b/git-submodule-cclone
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import subprocess, backwards, os, sys
 

--- a/git-submodule-describe
+++ b/git-submodule-describe
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import backwards, re, sys
 from copy import deepcopy


### PR DESCRIPTION
I don't know whether there was a specific reason for hardcoding /usr/bin/python but that does not work on systems where python is not in /usr/bin (e.g. freebsd).

Setuptools seems to replace the env python shebang fine.
